### PR TITLE
Updated host list

### DIFF
--- a/ps4-block
+++ b/ps4-block
@@ -72,3 +72,5 @@
 0.0.0.0 us.np.stun.playstation.net
 0.0.0.0 fswitch.dl.playstation.net
 0.0.0.0 rnps-crl.dl.playstation.net
+0.0.0.0 urlconfig.api.playstation.com
+0.0.0.0 crepo.ww.dl.playstation.net

--- a/ps4-block
+++ b/ps4-block
@@ -4,7 +4,7 @@
 # to disable any update from ps4. I'm just creating GitHub Raw Hosts data so everyone can use
 # This work is by depressive_monk, please give all the credit to him
 # https://www.reddit.com/user/depressive_monk/
-# Date: 26 May 2021
+# Date: 25 Dec 2023
 # 
 # ===============================================================
 0.0.0.0	dau01.ps4.update.playstation.net
@@ -64,3 +64,11 @@
 0.0.0.0	themis.dl.playstation.net
 0.0.0.0	tmdb.np.dl.playstation.net
 0.0.0.0	t-prof.np.community.playstation.net
+0.0.0.0 ps4-system.sec.np.dl.playstation.net
+0.0.0.0 event.api.np.km.playstation.net
+0.0.0.0 ps4updptl.uk.np.community.playstation.net
+0.0.0.0 static-resource.np.community.playstation.net
+0.0.0.0 csla.np.community.playstation.net
+0.0.0.0 us.np.stun.playstation.net
+0.0.0.0 fswitch.dl.playstation.net
+0.0.0.0 rnps-crl.dl.playstation.net


### PR DESCRIPTION
I recently started using this list with my PiHole and noticed that some hosts were not blocked and I was getting the "Update Ready" notification.

I added the URLs called up by my PS4 and now the notification is no longer present