### PR TITLE
Add ps4-block-domainonly.txt

### DIFF
--- a/ps4-block-domainonly.txt
+++ b/ps4-block-domainonly.txt
@@ -1,0 +1,76 @@
+# Title: ps4_dns_block/phoanglong
+#
+# This hosts file is a merged collection of hosts from depressive_monk
+# to disable any update from ps4. I'm just creating GitHub Raw Hosts data so everyone can use
+# This work is by depressive_monk, please give all the credit to him
+# https://www.reddit.com/user/depressive_monk/
+# Date: 25 Dec 2023
+# 
+# ===============================================================
+dau01.ps4.update.playstation.net
+dbr01.ps4.update.playstation.net
+dcn01.ps4.update.playstation.net
+deu01.ps4.update.playstation.net
+dhk01.ps4.update.playstation.net
+djp01.ps4.update.playstation.net
+dkr01.ps4.update.playstation.net
+dmx01.ps4.update.playstation.net
+dru01.ps4.update.playstation.net
+dsa01.ps4.update.playstation.net
+dtw01.ps4.update.playstation.net
+duk01.ps4.update.playstation.net
+dus01.ps4.update.playstation.net
+fau01.ps4.update.playstation.net
+fbr01.ps4.update.playstation.net
+fcn01.ps4.update.playstation.net
+feu01.ps4.update.playstation.net
+fhk01.ps4.update.playstation.net
+fjp01.ps4.update.playstation.net
+fkr01.ps4.update.playstation.net
+fmx01.ps4.update.playstation.net
+fru01.ps4.update.playstation.net
+fsa01.ps4.update.playstation.net
+ftw01.ps4.update.playstation.net
+fuk01.ps4.update.playstation.net
+fus01.ps4.update.playstation.net
+hau01.ps4.update.playstation.net
+hbr01.ps4.update.playstation.net
+hcn01.ps4.update.playstation.net
+heu01.ps4.update.playstation.net
+hhk01.ps4.update.playstation.net
+hjp01.ps4.update.playstation.net
+hkr01.ps4.update.playstation.net
+hmx01.ps4.update.playstation.net
+hru01.ps4.update.playstation.net
+hsa01.ps4.update.playstation.net
+htw01.ps4.update.playstation.net
+huk01.ps4.update.playstation.net
+hus01.ps4.update.playstation.net
+a01.cdn.update.playstation.org.edgesuite.net
+a192.d.akamai.net
+al02.cdn.update.playstation.net
+apicdn-p014.ribob01.net
+api-p014.ribob01.net
+artcdnsecure.ribob01.net
+asm.np.community.playstation.net
+get.net.playstation.net
+playstation.sony.akadns.net
+post.net.playstation.net
+ps4-eb.ww.np.dl.playstation.net
+ps4updptl.eu.np.community.playstation.net
+ps4updptl.jp.sp-int.community.playstation.net
+ps4.updptl.sp-int.community.playstation.net
+sf.api.np.km.playstation.net
+themis.dl.playstation.net
+tmdb.np.dl.playstation.net
+t-prof.np.community.playstation.net
+ps4-system.sec.np.dl.playstation.net
+event.api.np.km.playstation.net
+ps4updptl.uk.np.community.playstation.net
+static-resource.np.community.playstation.net
+csla.np.community.playstation.net
+us.np.stun.playstation.net
+fswitch.dl.playstation.net
+rnps-crl.dl.playstation.net
+urlconfig.api.playstation.com
+crepo.ww.dl.playstation.net


### PR DESCRIPTION
Same domains as `ps4-block`

Useful for e.g Diversion on Asus routers
